### PR TITLE
Fix ask_config quoting and error message

### DIFF
--- a/git-encrypt
+++ b/git-encrypt
@@ -35,7 +35,7 @@ function die() {
 function ask_config() {
   local key="$1" default="$2" message="$3"
   configured=$(git config --get "$key")
-  [ -z $configured ] && configured="$default"
+  [ -z "$configured" ] && configured="$default"
   echo -n "Input $message [$configured]:"
   read input
   [ -z "$input" ] && input=$configured
@@ -132,5 +132,5 @@ case "$COMMAND" in
   --clean) clean ;;
   --smudge) smudge ;;
   --diff) diff "$1" ;;
-  *) echo "Unknown option: ${option}"; "$0" -h; exit 1;;
+  *) echo "Unknown option: ${COMMAND}"; "$0" -h; exit 1;;
 esac


### PR DESCRIPTION
## Summary
- quote variable in ask_config to avoid test errors when values contain spaces
- fix undefined variable in unknown option handler

## Testing
- `bats test/git-encrypt.bats` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683b999b32488326a8e0052005cf6b01