### PR TITLE
Add help option test

### DIFF
--- a/test/git-encrypt.bats
+++ b/test/git-encrypt.bats
@@ -12,9 +12,11 @@ load helper
   [ $(expr "${lines[0]}" : "usage: git encrypt") -ne 0 ]
 }
 
-# TODO
-#@test "--help prints help" {
-#}
+@test "--help prints help" {
+  repo_run git-encrypt --help
+  [ $status -eq 0 ]
+  [ $(expr "${lines[0]}" : "usage: git encrypt") -ne 0 ]
+}
 
 @test "--install" {
   repo_run git-encrypt --install


### PR DESCRIPTION
## Summary
- add missing `--help` bats test

## Testing
- `bats test/git-encrypt.bats` *(fails: `bash: bats: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_683b9a463ccc8326a8434c3629e0a9b7