### PR TITLE
Fix README dependency name

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The git-encrypt depends on the following libraries:
 * [aws-cli](https://aws.amazon.com/jp/cli/)
   * ファイルの複合化のためにはデータキー用のKMSのキーに対する kms:Decrypt 権限が必要です
   * データキーを作成するには対象のKMSのキーに対する kms:GenerateDataKeyWithoutPlaintext 権限が必要です
-* [git-encryt-agent](https://github.com/ikeisuke/git-encrypt-agent/)
+* [git-encrypt-agent](https://github.com/ikeisuke/git-encrypt-agent/)
 
 
 ## プロジェクトへのインストール


### PR DESCRIPTION
## Summary
- fix typo in dependency name in README

## Testing
- `bash test/git-encrypt.bats` *(fails: `load: command not found` because bats isn't installed)*

------
https://chatgpt.com/codex/tasks/task_b_683b9a401d048326aa176c719dbd7618